### PR TITLE
Update ci.yml for disable build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         IS_PR: ${{ !!github.head_ref }}
       run: |
         if $IS_PR ; then echo $PR_PROMPT; fi
-        dotnet build --configuration Release --no-restore
+        dotnet build --configuration Release --no-restore --property WarningLevel=0
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       if: ${{ !github.head_ref }}


### PR DESCRIPTION
Making the action summary clean and easy to find the output.
Too many warnings to see the action build file.


There are about 100+ warnings and I think there won't be a plan to kill these warnings in a long time.
I have tried `WarningLevel=1` but still lots of warnings.
